### PR TITLE
Updates project setting to keep viewport standard

### DIFF
--- a/project/project.godot
+++ b/project/project.godot
@@ -19,6 +19,10 @@ config/icon="res://icon.svg"
 
 Music="*res://Scenes/music.tscn"
 
+[display]
+
+window/stretch/mode="viewport"
+
 [editor]
 
 version_control/plugin_name="GitPlugin"


### PR DESCRIPTION
When running the game in the browser, more of the game world would be visible than originally intended. This requires an update to the window viewport settings to adjust appropriately.